### PR TITLE
Issue #26 リファクタリング

### DIFF
--- a/infra/db/user_account.go
+++ b/infra/db/user_account.go
@@ -25,19 +25,19 @@ func NewUserAccount(email, name, passwordHash string) *UserAccount {
 	}
 }
 
-type UserAccountRepositoryImpl struct {
+type UserAccountRepository struct {
 	mysql gorm.DB
 }
 
-func NewUserAccountRepositoryImpl(client gorm.DB) (*UserAccountRepositoryImpl, error) {
-	return &UserAccountRepositoryImpl{
+func NewUserAccountRepository(client gorm.DB) (*UserAccountRepository, error) {
+	return &UserAccountRepository{
 		mysql: client,
 	}, nil
 }
 
-func (i *UserAccountRepositoryImpl) Find(id string) (*models.UserAccount, error) {
+func (r *UserAccountRepository) Find(id string) (*models.UserAccount, error) {
 	var account UserAccount
-	result := i.mysql.Where("id=?", id).First(&account)
+	result := r.mysql.Where("id=?", id).First(&account)
 	if err := result.Error; err != nil {
 		return nil, err
 	}
@@ -50,9 +50,9 @@ func (i *UserAccountRepositoryImpl) Find(id string) (*models.UserAccount, error)
 	}, nil
 }
 
-func (i *UserAccountRepositoryImpl) FindByEmail(email string) (*models.UserAccount, error) {
+func (r *UserAccountRepository) FindByEmail(email string) (*models.UserAccount, error) {
 	var account UserAccount
-	result := i.mysql.Where("email=?", email).First(&account)
+	result := r.mysql.Where("email=?", email).First(&account)
 	if err := result.Error; err != nil {
 		return nil, err
 	}
@@ -65,9 +65,9 @@ func (i *UserAccountRepositoryImpl) FindByEmail(email string) (*models.UserAccou
 	}, nil
 }
 
-func (i *UserAccountRepositoryImpl) List() ([]models.UserAccount, error) {
+func (r *UserAccountRepository) List() ([]models.UserAccount, error) {
 	var accounts []UserAccount
-	result := i.mysql.Find(&accounts)
+	result := r.mysql.Find(&accounts)
 	if err := result.Error; err != nil {
 		return nil, err
 	}
@@ -85,20 +85,20 @@ func (i *UserAccountRepositoryImpl) List() ([]models.UserAccount, error) {
 	return results, nil
 }
 
-func (i *UserAccountRepositoryImpl) Insert(email, name, password string) (*models.UserAccount, error) {
+func (r *UserAccountRepository) Insert(email, name, password string) (*models.UserAccount, error) {
 	encryptedPass, err := models.NewEncryptedPassword(password)
 	if err != nil {
 		return nil, err
 	}
 	account := NewUserAccount(email, name, encryptedPass.Hash)
 
-	result := i.mysql.Create(account)
+	result := r.mysql.Create(account)
 	if err := result.Error; err != nil {
 		return nil, err
 	}
 
 	var a UserAccount
-	result = i.mysql.Where("email = ?", account.Email).Find(&a)
+	result = r.mysql.Where("email = ?", account.Email).Find(&a)
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -111,19 +111,19 @@ func (i *UserAccountRepositoryImpl) Insert(email, name, password string) (*model
 	}, nil
 }
 
-func (i *UserAccountRepositoryImpl) Update(account models.UserAccount) (*models.UserAccount, error) {
+func (r *UserAccountRepository) Update(account models.UserAccount) (*models.UserAccount, error) {
 	encryptedPass, err := models.NewEncryptedPassword(account.Password)
 	if err != nil {
 		return nil, err
 	}
 	newAccount := UserAccount{Email: account.Email, Name: account.Name, Hash: encryptedPass.Hash}
-	result := i.mysql.Table("user_accounts").Where("id=?", account.ID).UpdateColumns(newAccount)
+	result := r.mysql.Table("user_accounts").Where("id=?", account.ID).UpdateColumns(newAccount)
 	if err := result.Error; err != nil {
 		return nil, err
 	}
 
 	var a UserAccount
-	result = i.mysql.Where("email = ?", account.Email).Find(&a)
+	result = r.mysql.Where("email = ?", account.Email).Find(&a)
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -136,13 +136,13 @@ func (i *UserAccountRepositoryImpl) Update(account models.UserAccount) (*models.
 	}, nil
 }
 
-func (i *UserAccountRepositoryImpl) Delete(id string) error {
+func (r *UserAccountRepository) Delete(id string) error {
 	deletedUUID, err := uuid.Parse(id)
 	if err != nil {
 		return nil
 	}
 
 	user := models.UserAccount{}
-	result := i.mysql.Delete(&user, deletedUUID)
+	result := r.mysql.Delete(&user, deletedUUID)
 	return result.Error
 }

--- a/infra/db/user_session.go
+++ b/infra/db/user_session.go
@@ -62,7 +62,7 @@ func (r UserSessionRepository) Verify(token string) error {
 	return nil
 }
 
-func (r UserSessionRepository) FindUser(token string) (string, error) {
+func (r UserSessionRepository) FindOwner(token string) (string, error) {
 	var sess UserSession
 	result := r.client.
 		Where("token = ? AND ? < expired_at", token, time.Now()).

--- a/main.go
+++ b/main.go
@@ -40,35 +40,37 @@ func main() {
 	jwtAuth := controller.NewJWTAuth(authSvc)
 
 	router := gin.Default()
-	router.GET("/users/:id", userAccountController.Get)
-
+	usersRouter := router.Group("users")
+	{
+		usersRouter.GET(":id", userAccountController.Get)
+		usersRouter.POST("new", userAccountController.Create)
+	}
 	userSessionRepo := db.NewUserSessionRepo(*dbClient)
 	storedAuthSvc := services.NewStoredAuthorization(userAccountRepo, userSessionRepo, env.AvailabilityTime)
 	storedAuth := controller.NewStoredAuth(storedAuthSvc)
-	v0 := router.Group("/v0")
+	v0 := router.Group("v0")
 	{
-		v0.POST("/login", storedAuth.Login)
+		v0.POST("login", storedAuth.Login)
 
-		v0usersRouter := v0.Group("/users")
+		v0UsersRouter := v0.Group("users")
 		{
-			v0usersRouter.POST("/new", userAccountController.Create)
-			v0usersRouter.Use(storedAuth.CheckAuthentication).GET("", userAccountController.List)
-			authedOwnerRouter := v0usersRouter.Use(storedAuth.CheckAuthenticatedOwner)
+			v0UsersRouter.Use(storedAuth.CheckAuthentication).GET("", userAccountController.List)
+			authedOwnerRouter := v0UsersRouter.Use(storedAuth.CheckAuthenticatedOwner)
 			{
-				authedOwnerRouter.PATCH("/:id", userAccountController.Update)
+				authedOwnerRouter.PATCH(":id", userAccountController.Update)
 				authedOwnerRouter.Use(storedAuth.CheckAuthenticatedOwner).
-					DELETE("/:id", userAccountController.Delete)
+					DELETE(":id", userAccountController.Delete)
 				authedOwnerRouter.Use(storedAuth.CheckAuthenticatedOwner).
-					DELETE("/logout/:id", storedAuth.Logout)
+					DELETE("logout/:id", storedAuth.Logout)
 			}
 		}
 	}
 
-	v1 := router.Group("/v1")
+	v1 := router.Group("v1")
 	{
-		v1.POST("/login", jwtAuth.Login)
+		v1.POST("login", jwtAuth.Login)
 
-		authRouter := v1.Group("/users").Use(jwtAuth.CheckAuthentication)
+		authRouter := v1.Group("users").Use(jwtAuth.CheckAuthentication)
 		{
 			authRouter.PATCH(":id", userAccountController.Update)
 			authRouter.DELETE(":id", userAccountController.Delete)

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("データベースクライアントの生成に失敗 : %s\n", err.Error())
 	}
-	userAccountRepo, err := db.NewUserAccountRepositoryImpl(*dbClient)
+	userAccountRepo, err := db.NewUserAccountRepository(*dbClient)
 	userAccountSvc := services.UserAccount{
 		Repo: userAccountRepo,
 	}

--- a/models/user_account.go
+++ b/models/user_account.go
@@ -7,7 +7,7 @@ type UserAccount struct {
 	Password string
 }
 
-type UserAccountRepository interface {
+type UserAccountAccessor interface {
 	Find(string) (*UserAccount, error)
 	FindByEmail(string) (*UserAccount, error)
 	List() ([]UserAccount, error)

--- a/models/user_session.go
+++ b/models/user_session.go
@@ -21,6 +21,6 @@ func NewSession(owner, token string, expiredAt time.Time) Session {
 type UserSessionAccessor interface {
 	Register(Session) (string, error)
 	Verify(string) error
-	FindUser(string) (string, error)
+	FindOwner(string) (string, error)
 	Delete(string, string) error
 }

--- a/services/authorizer.go
+++ b/services/authorizer.go
@@ -15,7 +15,7 @@ type Authorizer interface {
 	Verify(string) error
 }
 
-func NewAuthorizer(userAccountRepo models.UserAccountRepository, authorizer models.Authorizer) Authorization {
+func NewAuthorizer(userAccountRepo models.UserAccountAccessor, authorizer models.Authorizer) Authorization {
 	return Authorization{
 		userAccountRepo: userAccountRepo,
 		authorizer:      authorizer,
@@ -23,7 +23,7 @@ func NewAuthorizer(userAccountRepo models.UserAccountRepository, authorizer mode
 }
 
 type Authorization struct {
-	userAccountRepo models.UserAccountRepository
+	userAccountRepo models.UserAccountAccessor
 	authorizer      models.Authorizer
 }
 
@@ -58,7 +58,7 @@ type StoredAuthorizer interface {
 }
 
 func NewStoredAuthorization(
-	a models.UserAccountRepository,
+	a models.UserAccountAccessor,
 	s models.UserSessionAccessor,
 	availabilityTime time.Duration,
 ) StoredAuthorization {
@@ -70,7 +70,7 @@ func NewStoredAuthorization(
 }
 
 type StoredAuthorization struct {
-	userAccountRepo  models.UserAccountRepository
+	userAccountRepo  models.UserAccountAccessor
 	userSessionRepo  models.UserSessionAccessor
 	availabilityTime time.Duration
 }

--- a/services/authorizer.go
+++ b/services/authorizer.go
@@ -100,7 +100,7 @@ func (a StoredAuthorization) Verify(token string) error {
 }
 
 func (a StoredAuthorization) FindUser(id, token string) error {
-	owner, err := a.userSessionRepo.FindUser(token)
+	owner, err := a.userSessionRepo.FindOwner(token)
 	if err != nil {
 		return err
 	}

--- a/services/user_account.go
+++ b/services/user_account.go
@@ -3,7 +3,7 @@ package services
 import "auth-test/models"
 
 type UserAccount struct {
-	Repo models.UserAccountRepository
+	Repo models.UserAccountAccessor
 }
 
 func (a UserAccount) Find(id string) (*models.UserAccount, error) {


### PR DESCRIPTION
1. アカウントリポジトリインターフェース名をユーザセッションインターフェースと同じフォーマットにする
2. アカウントリポジトリ実装名をユーザセッション実装名と同じフォーマットにする
3. ルーティングをパスから/を削除するように修正
4. アカウント作成処理をバージョングループ外に移動