### PR TITLE
ISSUE-#24: refactor/fix_user_account_error_handling ユーザアカウントエラーハンドリング修正

### DIFF
--- a/infra/db/user_account.go
+++ b/infra/db/user_account.go
@@ -1,10 +1,15 @@
 package db
 
 import (
+	"errors"
+	"fmt"
+
+	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"auth-test/models"
+	"auth-test/services"
 )
 
 type UserAccounts struct {
@@ -38,7 +43,12 @@ func (r *UserAccountRepository) Find(id string) (*models.UserAccount, error) {
 	var account UserAccounts
 	result := r.mysql.Where("id=?", id).First(&account)
 	if err := result.Error; err != nil {
-		return nil, err
+		switch {
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			return nil, services.NewApplicationErr(services.NoUserRecord, err)
+		default:
+			return nil, services.NewApplicationErr(services.InternalServerErr, err)
+		}
 	}
 
 	response := models.NewUserAccount(account.ID, account.Email, account.Name, account.Hash)
@@ -49,7 +59,12 @@ func (r *UserAccountRepository) FindByEmail(email string) (*models.UserAccount, 
 	var account UserAccounts
 	result := r.mysql.Where("email=?", email).First(&account)
 	if err := result.Error; err != nil {
-		return nil, err
+		switch {
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			return nil, services.NewApplicationErr(services.NoUserEmail, err)
+		default:
+			return nil, services.NewApplicationErr(services.InternalServerErr, err)
+		}
 	}
 
 	response := models.NewUserAccount(account.ID, account.Email, account.Name, account.Hash)
@@ -60,7 +75,7 @@ func (r *UserAccountRepository) List() ([]models.UserAccount, error) {
 	var accounts []UserAccounts
 	result := r.mysql.Find(&accounts)
 	if err := result.Error; err != nil {
-		return nil, err
+		return nil, services.NewApplicationErr(services.NoUsersRecord, err)
 	}
 	var results []models.UserAccount
 	for _, account := range accounts {
@@ -74,19 +89,29 @@ func (r *UserAccountRepository) List() ([]models.UserAccount, error) {
 func (r *UserAccountRepository) Insert(id, email, name, password string) (*models.UserAccount, error) {
 	encryptedPass, err := models.NewEncryption(password)
 	if err != nil {
-		return nil, err
+		return nil, services.NewApplicationErr(services.TooLongPassword, err)
 	}
 	account := NewUserAccount(id, email, name, encryptedPass.Hash())
 
 	result := r.mysql.Create(account)
 	if err = result.Error; err != nil {
-		return nil, err
+		switch {
+		case err.(*mysql.MySQLError).Number == MySQLDuplicateEntry:
+			return nil, services.NewApplicationErr(services.DuplicateUserEmail, err)
+		default:
+			return nil, services.NewApplicationErr(services.InternalServerErr, err)
+		}
 	}
 
 	var a UserAccounts
 	result = r.mysql.Where("email = ?", email).Find(&a)
-	if result.Error != nil {
-		return nil, result.Error
+	if err = result.Error; err != nil {
+		switch {
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			return nil, services.NewApplicationErr(services.NoUserRecord, err)
+		default:
+			return nil, services.NewApplicationErr(services.InternalServerErr, err)
+		}
 	}
 
 	response := models.NewUserAccount(a.ID, a.Email, a.Name, a.Hash)
@@ -96,19 +121,21 @@ func (r *UserAccountRepository) Insert(id, email, name, password string) (*model
 func (r *UserAccountRepository) Update(account models.UserAccount) (*models.UserAccount, error) {
 	encryptedPass, err := models.NewEncryption(account.Password())
 	if err != nil {
-		return nil, err
+		return nil, services.NewApplicationErr(services.TooLongPassword, err)
 	}
 
 	newAccount := UserAccounts{Email: account.Email(), Name: account.Name(), Hash: encryptedPass.Hash()}
-	result := r.mysql.Table("user_accounts").Where("id=?", account.ID()).UpdateColumns(newAccount)
-	if err = result.Error; err != nil {
-		return nil, err
-	}
-
 	var a UserAccounts
-	result = r.mysql.Where("email = ?", account.Email()).Find(&a)
-	if result.Error != nil {
-		return nil, result.Error
+	result := r.mysql.Table("user_accounts").Where("id = ?", account.ID()).UpdateColumns(newAccount).First(&a)
+	if err = result.Error; err != nil {
+		switch {
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			return nil, services.NewApplicationErr(services.NoUserRecord, err)
+		case err.(*mysql.MySQLError).Number == MySQLDuplicateEntry:
+			return nil, services.NewApplicationErr(services.DuplicateUserEmail, err)
+		default:
+			return nil, services.NewApplicationErr(services.InternalServerErr, err)
+		}
 	}
 
 	response := models.NewUserAccount(a.ID, a.Email, a.Name, a.Hash)
@@ -118,12 +145,14 @@ func (r *UserAccountRepository) Update(account models.UserAccount) (*models.User
 func (r *UserAccountRepository) Delete(id string) error {
 	deletedUUID, err := uuid.Parse(id)
 	if err != nil {
-		return err
+		return services.NewApplicationErr(services.InvalidUUIDFormat, err)
 	}
-	var user models.UserAccount
-	result := r.mysql.Where("id = ?", deletedUUID).Delete(&user)
-	if result.Error != nil {
-		return result.Error
+
+	result := r.mysql.Delete(&UserAccounts{}, deletedUUID)
+	if result.RowsAffected == NoDeleteRecords {
+		return services.NewApplicationErr(services.NoUserRecord, fmt.Errorf("削除対象ID: %s", id))
+	} else if result.Error != nil {
+		return services.NewApplicationErr(services.InternalServerErr, result.Error)
 	}
 	return nil
 }

--- a/services/user_account.go
+++ b/services/user_account.go
@@ -13,7 +13,7 @@ type UserAccount struct {
 func (a UserAccount) Find(id string) (*models.UserAccount, error) {
 	account, err := a.repo.Find(id)
 	if err != nil {
-		return nil, err
+		return nil, NewApplicationErr(FailedShowUser, err)
 	}
 	return account, nil
 }
@@ -21,7 +21,7 @@ func (a UserAccount) Find(id string) (*models.UserAccount, error) {
 func (a UserAccount) FindByEmail(email string) (*models.UserAccount, error) {
 	account, err := a.repo.FindByEmail(email)
 	if err != nil {
-		return nil, err
+		return nil, NewApplicationErr(FailedShowUser, err)
 	}
 	return account, nil
 }
@@ -29,28 +29,30 @@ func (a UserAccount) FindByEmail(email string) (*models.UserAccount, error) {
 func (a UserAccount) List() ([]models.UserAccount, error) {
 	accounts, err := a.repo.List()
 	if err != nil {
-		return nil, err
+		return nil, NewApplicationErr(FailedListUser, err)
 	}
 	return accounts, nil
 }
 
 func (a UserAccount) Create(account models.UserAccount) (*models.UserAccount, error) {
-	updated, err := a.repo.Insert(account.ID(), account.Email(), account.Name(), account.Password())
+	user, err := a.repo.Insert(account.ID(), account.Email(), account.Name(), account.Password())
 	if err != nil {
-		return nil, err
+		return nil, NewApplicationErr(FailedCreateUser, err)
 	}
-	return updated, nil
+	return user, nil
 }
 
 func (a UserAccount) Update(account models.UserAccount) (*models.UserAccount, error) {
 	updated, err := a.repo.Update(account)
 	if err != nil {
-		return nil, err
+		return nil, NewApplicationErr(FailedUpdateUser, err)
 	}
 	return updated, nil
 }
 
 func (a UserAccount) Delete(id string) error {
-	err := a.repo.Delete(id)
-	return err
+	if err := a.repo.Delete(id); err != nil {
+		return NewApplicationErr(FailedDeleteUser, err)
+	}
+	return nil
 }


### PR DESCRIPTION
ユーザアカウント処理でエラーをラップする処理を追加

DB処理のエラーをラップして返却するように修正
パスワードの暗号化エラーをラップ
レコードが存在しない場合のエラーをラップ
ユーザEmailの重複エラーをラップ
UUIDのパースエラーをラップ