### PR TITLE
ISSUE-#24: refactor/fix_error_response APIエラーレスポンス修正

### DIFF
--- a/infra/controller/response.go
+++ b/infra/controller/response.go
@@ -1,21 +1,47 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
+
+	"auth-test/services"
 )
 
-func newErrorResponse(message string, detail string) errorResponse {
-	return errorResponse{
+func newValidationErr(message string, detail string) errResponse {
+	return errResponse{
 		Message: message,
 		Detail:  detail,
 	}
 }
 
-type errorResponse struct {
+type errResponse struct {
 	Message string `json:"message"`
 	Detail  string `json:"detail,omitempty"`
 }
 
-func (r errorResponse) Error() string {
-	return fmt.Sprintf("%s: %s", r.Message, r.Detail)
+func (e errResponse) Error() string {
+	return fmt.Sprintf("%s: %s", e.Message, e.Detail)
+}
+
+func newErrResponse(err error, detail string) (status int, responseErr errResponse) {
+	applicationErr := errors.Unwrap(err)
+	switch {
+	case errors.Is(applicationErr, services.InternalServerErr):
+		status = http.StatusInternalServerError
+	case errors.Is(applicationErr, services.EmptyToken):
+		status = http.StatusForbidden
+	default:
+		status = http.StatusBadRequest
+	}
+
+	var detailMsg string
+	if detail != "" {
+		detailMsg = fmt.Sprintf(": %s", detail)
+	}
+
+	return status, errResponse{
+		Message: err.Error(),
+		Detail:  fmt.Sprintf("%s%s", errors.Unwrap(err).Error(), detailMsg),
+	}
 }

--- a/infra/controller/user_accounts.go
+++ b/infra/controller/user_accounts.go
@@ -43,24 +43,24 @@ func (h UserAccountHandler) Get(c *gin.Context) {
 	var params userPathParams
 	if err := c.BindUri(&params); err != nil {
 		pathParamErr := newPathParamError(err.(validator.ValidationErrors)[0])
-		c.JSON(http.StatusBadRequest, pathParamErr.getResponse())
+		c.AbortWithStatusJSON(http.StatusBadRequest, pathParamErr.getResponse())
 		return
 	}
 
 	userAccount, err := h.service.Find(params.ID)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, err.Error())
-		return
+		status, response := newErrResponse(err, params.ID)
+		c.AbortWithStatusJSON(status, response)
 	}
 
 	c.JSON(http.StatusOK, userAccountResponse{ID: userAccount.ID(), Email: userAccount.Email(), Name: userAccount.Name()})
 }
 
-// List TODO ページネーションやオーダーをつける?
 func (h UserAccountHandler) List(c *gin.Context) {
 	accounts, err := h.service.List()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, err.Error())
+		status, response := newErrResponse(err, "")
+		c.AbortWithStatusJSON(status, response)
 		return
 	}
 
@@ -77,7 +77,7 @@ func (h *UserAccountHandler) Create(c *gin.Context) {
 	err := c.Bind(&account)
 	if err != nil {
 		accountBodyParam := newAccountBodyError(err.(validator.ValidationErrors)[0])
-		c.JSON(http.StatusBadRequest, accountBodyParam.getResponse())
+		c.AbortWithStatusJSON(http.StatusBadRequest, accountBodyParam.getResponse())
 		return
 	}
 
@@ -85,7 +85,8 @@ func (h *UserAccountHandler) Create(c *gin.Context) {
 		models.NewUserAccount(uuid.New().String(), account.Email, account.Name, account.Password),
 	)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, err.Error())
+		status, response := newErrResponse(err, account.Email)
+		c.AbortWithStatusJSON(status, response)
 		return
 	}
 
@@ -96,14 +97,14 @@ func (h *UserAccountHandler) Update(c *gin.Context) {
 	var params userPathParams
 	if err := c.BindUri(&params); err != nil {
 		pathParamErr := newPathParamError(err.(validator.ValidationErrors)[0])
-		c.JSON(http.StatusBadRequest, pathParamErr.getResponse())
+		c.AbortWithStatusJSON(http.StatusBadRequest, pathParamErr.getResponse())
 		return
 	}
 	var account inputUserAccount
 	err := c.BindJSON(&account)
 	if err != nil {
 		accountBodyParam := newAccountBodyError(err.(validator.ValidationErrors)[0])
-		c.JSON(http.StatusBadRequest, accountBodyParam.getResponse())
+		c.AbortWithStatusJSON(http.StatusBadRequest, accountBodyParam.getResponse())
 		return
 	}
 
@@ -112,7 +113,8 @@ func (h *UserAccountHandler) Update(c *gin.Context) {
 	)
 
 	if err != nil {
-		c.JSON(http.StatusBadRequest, err.Error())
+		status, response := newErrResponse(err, account.Email)
+		c.AbortWithStatusJSON(status, response)
 		return
 	}
 
@@ -123,12 +125,13 @@ func (h UserAccountHandler) Delete(c *gin.Context) {
 	var params userPathParams
 	if err := c.BindUri(&params); err != nil {
 		pathParamErr := newPathParamError(err.(validator.ValidationErrors)[0])
-		c.JSON(http.StatusBadRequest, pathParamErr.getResponse())
+		c.AbortWithStatusJSON(http.StatusBadRequest, pathParamErr.getResponse())
 		return
 	}
 	err := h.service.Delete(params.ID)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, err.Error())
+		status, response := newErrResponse(err, params.ID)
+		c.AbortWithStatusJSON(status, response)
 		return
 	}
 

--- a/infra/controller/validation.go
+++ b/infra/controller/validation.go
@@ -11,10 +11,6 @@ var (
 	passwordValidate = nspv.NewValidator()
 )
 
-type validateError interface {
-	getResponse() errorResponse
-}
-
 func newPathParamError(err validator.FieldError) pathParamError {
 	return pathParamError{
 		err: err,
@@ -25,12 +21,12 @@ type pathParamError struct {
 	err validator.FieldError
 }
 
-func (e pathParamError) getResponse() errorResponse {
-	var response errorResponse
+func (e pathParamError) getResponse() errResponse {
+	var response errResponse
 	errorMsg := e.err
 	switch errorMsg.Field() {
 	case "ID":
-		response = newErrorResponse(
+		response = newValidationErr(
 			fmt.Sprintf("ユーザIDの値 %s は不正なフォーマットです", errorMsg.Value()),
 			"フォーマットを 12345678-89ab-cdef-ghij-klmopqrstuvw にして下さい",
 		)
@@ -64,17 +60,17 @@ type AuthBodyError struct {
 }
 
 // TODO バリデーションエラーの詳細な情報を情報を取得する方法を調査する
-func (e AuthBodyError) getResponse() errorResponse {
-	var response errorResponse
+func (e AuthBodyError) getResponse() errResponse {
+	var response errResponse
 	errorMsg := e.err
 	switch errorMsg.Field() {
 	case "Password":
-		response = newErrorResponse(
+		response = newValidationErr(
 			"パスワードが不正なフォーマットです",
 			"",
 		)
 	case "Email":
-		response = newErrorResponse(
+		response = newValidationErr(
 			fmt.Sprintf("emailアドレス %s は不正なフォーマットです", errorMsg.Value()),
 			"",
 		)


### PR DESCRIPTION
APIから返却するエラーレスポンスを修正

エラー時のレスポンスをAbortWithStatusJSONで返すよう修正
エラー構造体をAPIレスポンス型に変換する関数を実装
空トークンの検証処理のみ直接返却するように修正