### PR TITLE
develop: 環境変数モジュール移動

### DIFF
--- a/infra/configuration/environment.go
+++ b/infra/configuration/environment.go
@@ -1,4 +1,4 @@
-package infra
+package configuration
 
 import "time"
 

--- a/migration/main.go
+++ b/migration/main.go
@@ -9,13 +9,13 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 
-	"auth-test/infra"
+	"auth-test/infra/configuration"
 	"auth-test/infra/db"
 	"auth-test/models"
 )
 
 func main() {
-	var env infra.Environment
+	var env configuration.Environment
 	err := envconfig.Process("", &env)
 
 	if err != nil {


### PR DESCRIPTION
main内からrouter呼び出し元がわかりやすいように他のモジュールはパッケージに移動

Environmentのインポートパスを修正
引数から不要なポインタ型定義を削除