### PR TITLE
ISSUE-#25: refactor/fix_db_migration マイグレーション時にデフォルトユーザ作成処理を削除

### DIFF
--- a/infra/configuration/environment.go
+++ b/infra/configuration/environment.go
@@ -3,9 +3,6 @@ package configuration
 import "time"
 
 type Environment struct {
-	Email             string        `envconfig:"EMAIL" required:"true"`
-	UserPassword      string        `envconfig:"USER_PASSWORD" required:"true"`
-	UserName          string        `envconfig:"USER_NAME" required:"true"`
 	User              string        `default:"root"`
 	Password          string        `required:"true"`
 	Host              string        `default:"0.0.0.0"`

--- a/migration/main.go
+++ b/migration/main.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 
 	"auth-test/infra/configuration"
 	"auth-test/infra/db"
-	"auth-test/models"
 )
 
 func main() {
@@ -44,16 +42,4 @@ func main() {
 	if err != nil {
 		log.Fatalf("テーブルのマイグレーションに失敗。: %s \n", err.Error())
 	}
-
-	newID := uuid.New()
-	encrypted, err := models.NewEncryption(env.UserPassword)
-	if err != nil {
-		log.Fatal("パスワードの保存に失敗")
-	}
-	mysqlDB.Create(&db.UserAccounts{
-		ID:    newID.String(),
-		Email: env.Email,
-		Name:  env.UserName,
-		Hash:  encrypted.Hash(),
-	})
 }


### PR DESCRIPTION
swaggerでユーザの作成を行えるようになったので修正

環境変数からユーザ作成用変数削除
migrationファイルから作成処理を削除